### PR TITLE
fix-variable

### DIFF
--- a/src/readqps.jl
+++ b/src/readqps.jl
@@ -528,7 +528,7 @@ function readqps(filename::String)
             bounds_section_read && error("more than one BOUNDS section specified")
             columns_section_read || error("COLUMNS section must come before BOUNDS section")
             lvar, uvar = read_bounds_section(qps, varnames)
-            bound_section_read = true
+            bounds_section_read = true
             # @show lvar
             # @show uvar
         end


### PR DESCRIPTION
Fixed typing error. The variable 'bounds_section_read', in the 'readqps ()' function, was not assuming the value 'true' when required, due to a typing error.