### PR TITLE
Perf

### DIFF
--- a/src/readqps.jl
+++ b/src/readqps.jl
@@ -257,10 +257,11 @@ function read_rows_line!(qps::QPSData, card::MPSCard)
 
     if rtype == RTYPE_N
         # Objective row
-        if isnothing(qps.objname)
+        if qps.objname === nothing
             # Record objective
             qps.objname = rowname
             qps.conindices[rowname] = 0
+            @info "Using '$rowname' as objective (l. $(card.nline))"
         else
             # Record name but ignore input
             @warn "Detected rim objective row $rowname at line $(card.nline)"
@@ -371,9 +372,10 @@ function read_rhs_line!(qps::QPSData, card::MPSCard)
     )
 
     rhs = card.f2
-    if isnothing(qps.rhsname)
+    if qps.rhsname === nothing
         # Record this as the RHS
         qps.rhsname = rhs
+        @info "Using '$rhs' as RHS (l. $(card.nline))"
     elseif qps.rhsname != rhs
         # Rim RHS, ignore this line
         @error "Skipping line $(card.nline) with rim RHS $rhs"
@@ -452,9 +454,10 @@ function read_ranges_line!(qps::QPSData, card::MPSCard)
     )
     
     rng = card.f2
-    if isnothing(qps.rngname)
+    if qps.rngname === nothing
         # Record this as the RANGES
         qps.rngname = rng
+        @info "Using '$rng' as RANGES (l. $(card.nline))"
     elseif qps.rngname != rng
         # Rim RANGES, ignore this line
         @error "Skipping line $(card.nline) with rim RANGES $rng"
@@ -521,9 +524,10 @@ function read_bounds_line!(qps::QPSData, card::MPSCard)
     )
 
     bnd = card.f2
-    if isnothing(qps.bndname)
+    if qps.bndname === nothing
         # Record this as the BOUNDS
         qps.bndname = bnd
+        @info "Using '$bnd' as BOUNDS (l. $(card.nline))"
     elseif qps.bndname != bnd
         # Rim BOUNDS, ignore this line
         @error "Skipping line $(card.nline) with rim bound $bnd"
@@ -641,6 +645,7 @@ function readqps(filename::String)
                 name_section_read && error("more than one NAME section specified")
                 qpsdat.name = card.f2
                 name_section_read = true
+                @info "Using '$(qpsdat.name)' as NAME (l. $(card.nline))"
             elseif sec == OBJ_SENSE
                 objsense_section_read && error("more than one OBJSENSE section specified")
                 objsense_section_read = true
@@ -703,13 +708,6 @@ function readqps(filename::String)
     close(qps)
 
     endata_read || @error("reached end of file before ENDATA section")
-
-    @info("Problem name     : $(qpsdat.name)")
-    @info("Objective sense  : $(qpsdat.objsense)")
-    @info("Objective name   : $(qpsdat.objname)")
-    rhs_section_read && @info("RHS              : $(qpsdat.rhsname)")
-    ranges_section_read && @info("RANGES           : $(qpsdat.rngname)")
-    bounds_section_read && @info("BOUNDS           : $(qpsdat.bndname)")
 
     return qpsdat
 end

--- a/test/dat/rim_bnd.qps
+++ b/test/dat/rim_bnd.qps
@@ -1,0 +1,16 @@
+NAME          RimObj
+ROWS
+ N  obj
+ G  r1
+ L  r2
+COLUMNS
+    c1        r1                2.0    r2               -1.0
+    c1        obj               1.5
+    c2        r1                1.0    r2                2.0
+    c2        obj              -2.0
+BOUNDS
+ UP  bnd1      c1               20.0
+ UP  bnd2      c1               10.0
+ LO  bnd1      c2                1.0
+ UP  bnd2      c2               10.0
+ENDATA

--- a/test/dat/rim_bnd.qps
+++ b/test/dat/rim_bnd.qps
@@ -1,4 +1,4 @@
-NAME          RimObj
+NAME          RimBOUNDS
 ROWS
  N  obj
  G  r1

--- a/test/qp-example.jl
+++ b/test/qp-example.jl
@@ -15,7 +15,7 @@ using SparseArrays
         (:info, "Objective sense  : notset"),
         (:info, "Objective name   : obj"),
         (:info, "RHS              : rhs1"),
-        (:info, "RANGES           : "),
+        (:info, "RANGES           : nothing"),
         (:info, "BOUNDS           : bnd1"),
         match_mode = :all,
         readqps("dat/qp-example.qps")
@@ -25,7 +25,7 @@ using SparseArrays
     @test qp.objname == "obj"
     @test qp.rhsname == "rhs1"
     @test qp.bndname == "bnd1"
-    @test qp.rngname == ""
+    @test isnothing(qp.rngname)
 
     @test qp.nvar == 2
     @test qp.ncon == 2

--- a/test/qp-example.jl
+++ b/test/qp-example.jl
@@ -11,12 +11,10 @@ using SparseArrays
     # Note that logs won't display since they are captured by the test macro
     qp = @test_logs(
         # These logs must appear in exactly this order
-        (:info, "Problem name     : QP example"),
-        (:info, "Objective sense  : notset"),
-        (:info, "Objective name   : obj"),
-        (:info, "RHS              : rhs1"),
-        (:info, "RANGES           : nothing"),
-        (:info, "BOUNDS           : bnd1"),
+        (:info, "Using 'QP example' as NAME (l. 1)"),
+        (:info, "Using 'obj' as objective (l. 3)"),
+        (:info, "Using 'rhs1' as RHS (l. 12)"),
+        (:info, "Using 'bnd1' as BOUNDS (l. 16)"),
         match_mode = :all,
         readqps("dat/qp-example.qps")
     )
@@ -25,7 +23,7 @@ using SparseArrays
     @test qp.objname == "obj"
     @test qp.rhsname == "rhs1"
     @test qp.bndname == "bnd1"
-    @test isnothing(qp.rngname)
+    @test qp.rngname === nothing
 
     @test qp.nvar == 2
     @test qp.ncon == 2

--- a/test/rimdata.jl
+++ b/test/rimdata.jl
@@ -3,13 +3,13 @@
     @testset "Objective" begin
 
         qp = @test_logs(
-            (:warn, "Detected rim objective row obj2."),
-            (:warn, "Detected rim objective row obj3."),
-            (:error, "Ignoring coefficient (obj2, c1) with value 2.2"),
-            (:error, "Ignoring coefficient (obj2, c2) with value -2.2"),
-            (:error, "Ignoring coefficient (obj3, c1) with value 2.3"),
-            (:error, "Ignoring coefficient (obj3, c2) with value -2.3"),
-            (:error, "Ignoring RHS for rim objective obj2"),
+            (:warn, "Detected rim objective row obj2 at line 4"),
+            (:warn, "Detected rim objective row obj3 at line 7"),
+            (:error, "Ignoring coefficient (obj2, c1) with value 2.2 at line 10"),
+            (:error, "Ignoring coefficient (obj2, c2) with value -2.2 at line 12"),
+            (:error, "Ignoring coefficient (obj3, c1) with value 2.3 at line 13"),
+            (:error, "Ignoring coefficient (obj3, c2) with value -2.3 at line 14"),
+            (:error, "Ignoring RHS for rim objective obj2 at line 16"),
             (:info, "Problem name     : RimObj"),
             (:info, "Objective sense  : notset"),
             (:info, "Objective name   : obj1"),
@@ -37,9 +37,9 @@
     @testset "RHS" begin
         qp = @test_logs(
             # These logs should appear in exactly this order
-            (:error, "Skipping line with rim RHS rhs2"),
-            (:error, "Skipping line with rim RHS rhs2"),
-            (:error, "Skipping line with rim RHS rhs3"),
+            (:error, "Skipping line 13 with rim RHS rhs2"),
+            (:error, "Skipping line 15 with rim RHS rhs2"),
+            (:error, "Skipping line 16 with rim RHS rhs3"),
             (:info, "Problem name     : RimRHS"),
             (:info, "Objective sense  : notset"),
             (:info, "Objective name   : obj1"),
@@ -60,7 +60,7 @@
         qp = @test_logs(
             # These logs should appear in exactly this order
             # (:warn, "Detected rim range rng2"),
-            (:error, "Skipping line with rim RANGES rng2"),
+            (:error, "Skipping line 16 with rim RANGES rng2"),
             (:info, "Problem name     : RimRANGES"),
             (:info, "Objective sense  : notset"),
             (:info, "Objective name   : obj1"),
@@ -80,8 +80,8 @@
         qp = @test_logs(
             # These logs should appear in exactly this order
             # (:warn, "Detected rim range rng2"),
-            (:error, "Skipping line with rim bound bnd2"),
-            (:error, "Skipping line with rim bound bnd2"),
+            (:error, "Skipping line 13 with rim bound bnd2"),
+            (:error, "Skipping line 15 with rim bound bnd2"),
             (:info, "Problem name     : RimObj"),
             (:info, "Objective sense  : notset"),
             (:info, "Objective name   : obj"),

--- a/test/rimdata.jl
+++ b/test/rimdata.jl
@@ -3,17 +3,16 @@
     @testset "Objective" begin
 
         qp = @test_logs(
+            (:info, "Using 'RimObj' as NAME (l. 1)"),
+            (:info, "Using 'obj1' as objective (l. 3)"),
             (:warn, "Detected rim objective row obj2 at line 4"),
             (:warn, "Detected rim objective row obj3 at line 7"),
             (:error, "Ignoring coefficient (obj2, c1) with value 2.2 at line 10"),
             (:error, "Ignoring coefficient (obj2, c2) with value -2.2 at line 12"),
             (:error, "Ignoring coefficient (obj3, c1) with value 2.3 at line 13"),
             (:error, "Ignoring coefficient (obj3, c2) with value -2.3 at line 14"),
+            (:info, "Using 'rhs1' as RHS (l. 16)"),
             (:error, "Ignoring RHS for rim objective obj2 at line 16"),
-            (:info, "Problem name     : RimObj"),
-            (:info, "Objective sense  : notset"),
-            (:info, "Objective name   : obj1"),
-            (:info, "RHS              : rhs1"),
             match_mode = :all,
             readqps("dat/rim_obj.qps")
         )
@@ -37,13 +36,12 @@
     @testset "RHS" begin
         qp = @test_logs(
             # These logs should appear in exactly this order
+            (:info, "Using 'RimRHS' as NAME (l. 1)"),
+            (:info, "Using 'obj1' as objective (l. 3)"),
+            (:info, "Using 'rhs1' as RHS (l. 12)"),
             (:error, "Skipping line 13 with rim RHS rhs2"),
             (:error, "Skipping line 15 with rim RHS rhs2"),
             (:error, "Skipping line 16 with rim RHS rhs3"),
-            (:info, "Problem name     : RimRHS"),
-            (:info, "Objective sense  : notset"),
-            (:info, "Objective name   : obj1"),
-            (:info, "RHS              : rhs1"),
             match_mode = :all,
             readqps("dat/rim_rhs.qps")
         )
@@ -59,13 +57,11 @@
     @testset "Range" begin
         qp = @test_logs(
             # These logs should appear in exactly this order
-            # (:warn, "Detected rim range rng2"),
+            (:info, "Using 'RimRANGES' as NAME (l. 1)"),
+            (:info, "Using 'obj1' as objective (l. 3)"),
+            (:info, "Using 'rhs1' as RHS (l. 12)"),
+            (:info, "Using 'rng1' as RANGES (l. 15)"),
             (:error, "Skipping line 16 with rim RANGES rng2"),
-            (:info, "Problem name     : RimRANGES"),
-            (:info, "Objective sense  : notset"),
-            (:info, "Objective name   : obj1"),
-            (:info, "RHS              : rhs1"),
-            (:info, "RANGES           : rng1"),
             match_mode = :all,
             readqps("dat/rim_rng.qps")
         )
@@ -79,13 +75,11 @@
     @testset "Bounds" begin
         qp = @test_logs(
             # These logs should appear in exactly this order
-            # (:warn, "Detected rim range rng2"),
+            (:info, "Using 'RimBOUNDS' as NAME (l. 1)"),
+            (:info, "Using 'obj' as objective (l. 3)"),
+            (:info, "Using 'bnd1' as BOUNDS (l. 12)"),
             (:error, "Skipping line 13 with rim bound bnd2"),
             (:error, "Skipping line 15 with rim bound bnd2"),
-            (:info, "Problem name     : RimObj"),
-            (:info, "Objective sense  : notset"),
-            (:info, "Objective name   : obj"),
-            (:info, "BOUNDS           : bnd1"),
             match_mode = :all,
             readqps("dat/rim_bnd.qps")
         )

--- a/test/rimdata.jl
+++ b/test/rimdata.jl
@@ -3,7 +3,8 @@
     @testset "Objective" begin
 
         qp = @test_logs(
-            (:warn, "Detected rim objective obj2.\nThis row and subsequent objective rows will be ignored."),
+            (:warn, "Detected rim objective row obj2."),
+            (:warn, "Detected rim objective row obj3."),
             (:error, "Ignoring coefficient (obj2, c1) with value 2.2"),
             (:error, "Ignoring coefficient (obj2, c2) with value -2.2"),
             (:error, "Ignoring coefficient (obj3, c1) with value 2.3"),
@@ -35,11 +36,10 @@
 
     @testset "RHS" begin
         qp = @test_logs(
-            # These logs must appear in exactly this order
-            (:warn, "Detected rim RHS rhs2"),
-            (:error, "Skipping line for rim RHS rhs2"),
-            (:error, "Skipping line for rim RHS rhs2"),
-            (:error, "Skipping line for rim RHS rhs3"),
+            # These logs should appear in exactly this order
+            (:error, "Skipping line with rim RHS rhs2"),
+            (:error, "Skipping line with rim RHS rhs2"),
+            (:error, "Skipping line with rim RHS rhs3"),
             (:info, "Problem name     : RimRHS"),
             (:info, "Objective sense  : notset"),
             (:info, "Objective name   : obj1"),
@@ -57,18 +57,18 @@
     end
 
     @testset "Range" begin
-    qp = @test_logs(
-        # These logs must appear in exactly this order
-        (:warn, "Detected rim range rng2"),
-        (:error, "Skipping line for rim range rng2"),
-        (:info, "Problem name     : RimRANGES"),
-        (:info, "Objective sense  : notset"),
-        (:info, "Objective name   : obj1"),
-        (:info, "RHS              : rhs1"),
-        (:info, "RANGES           : rng1"),
-        match_mode = :all,
-        readqps("dat/rim_rng.qps")
-    )
+        qp = @test_logs(
+            # These logs should appear in exactly this order
+            # (:warn, "Detected rim range rng2"),
+            (:error, "Skipping line with rim RANGES rng2"),
+            (:info, "Problem name     : RimRANGES"),
+            (:info, "Objective sense  : notset"),
+            (:info, "Objective name   : obj1"),
+            (:info, "RHS              : rhs1"),
+            (:info, "RANGES           : rng1"),
+            match_mode = :all,
+            readqps("dat/rim_rng.qps")
+        )
 
         @test qp.rngname == "rng1"
 
@@ -77,6 +77,23 @@
     end
 
     @testset "Bounds" begin
+        qp = @test_logs(
+            # These logs should appear in exactly this order
+            # (:warn, "Detected rim range rng2"),
+            (:error, "Skipping line with rim bound bnd2"),
+            (:error, "Skipping line with rim bound bnd2"),
+            (:info, "Problem name     : RimObj"),
+            (:info, "Objective sense  : notset"),
+            (:info, "Objective name   : obj"),
+            (:info, "BOUNDS           : bnd1"),
+            match_mode = :all,
+            readqps("dat/rim_bnd.qps")
+        )
+
+        @test qp.bndname == "bnd1"
+
+        @test qp.lvar == [0.0, 1.0]
+        @test qp.uvar == [20.0, Inf]
     end
 
 end


### PR DESCRIPTION
Basically a close-to-full re-write, with major performance improvements (see below).
The diff will be horrible, since virtually no line was left untouched.

The main differences are as follows:
* Instead of parsing each section in a separate function (with lots of duplicate code), I introduced the `MPSCard` structure for extracting fields. Not all fields are always strings or always numbers, so only strings are extracted.
I then replaced `read_XXX_section` with `read_XXX_line`, which only handles the parsing of fields, which shortens the functions and removes a lot of duplicate code.
This approach should make it (much) easier to support Free MPS format, since only the `read_card!` function will have to be modified
* Strings are converted to integers whenever possible (e.g., for handling section headers), and hashes are computed as rarely as possible.
* The `QPSData` object is created at the beginning of `readqps`, and modified in-place. This saves a lot of memory

Other minors differences:
* Error messages now display the line number
* No error is thrown if the `RANGES` section is read before the `RHS` section. This is because, in absence of an `RHS` section, all right-hand sides are assumed to be zero.
However, an error is thrown if `RANGES` appears before `RHS`.
* I removed the `@warn` for the first time a rim field is detected. Instead, a `@error` log is displayed every time such data is encountered. Tests were updated accordingly.


Compared to the master branch, ~75% decrease in time, and ~85% decrease in memory:

| ID           | time ratio                   | memory ratio                 |
|--------------|------------------------------|------------------------------|
| `["maros"]`  | 0.27 (5%) :white_check_mark: | 0.17 (1%) :white_check_mark: |
| `["netlib"]` | 0.25 (5%) :white_check_mark: | 0.15 (1%) :white_check_mark: |

Other solvers do not read `.SIF` files, so explicit comparison is not possible on this testset.
Nevertheless, reading all NETLIB instances (which I manually converted to MPS) with Gurobi (through its Julia API) takes ~1.5s, compared to ~6s for QPSReader.