### PR TITLE
Free mps

### DIFF
--- a/src/readqps.jl
+++ b/src/readqps.jl
@@ -572,7 +572,7 @@ function read_ranges_line!(qps::QPSData, card::MPSCard)
         rtype = qps.contypes[row]
         if rtype == RTYPE_E
             if val >= 0.0
-                qps.ucon += val
+                qps.ucon[row] += val
             else
                 qps.lcon[row] += val
             end
@@ -598,7 +598,7 @@ function read_ranges_line!(qps::QPSData, card::MPSCard)
         rtype = qps.contypes[row]
         if rtype == RTYPE_E
             if val >= 0.0
-                qps.ucon += val
+                qps.ucon[row] += val
             else
                 qps.lcon[row] += val
             end

--- a/src/readqps.jl
+++ b/src/readqps.jl
@@ -260,7 +260,7 @@ function read_card!(card::MPSCard{FreeMPS}, ln::String)
         card.f1 = String(s[1])
         # Read name, if applicable
         if card.f1 == "NAME"
-            card.f2 = s[2]
+            card.f2 = length(s) >= 2 ? s[2] : ""
             card.nfields = 2
         elseif card.f1 == "OBJECT"
             if s[2] == "BOUND"

--- a/test/dat/qp-example.qps
+++ b/test/dat/qp-example.qps
@@ -1,4 +1,4 @@
-NAME          QP example
+NAME          QPexample
 ROWS
  N  obj
  G  r1

--- a/test/qp-example.jl
+++ b/test/qp-example.jl
@@ -5,41 +5,46 @@ using SparseArrays
 # Technical Report DOC 97/6, Department of Computing, Imperial College, London, UK, 1997
 # http://www.doc.ic.ac.uk/rr2000/DTR97-6.pdf
 
+
 @testset "QP example" begin
+    for format in [:fixed, :free]
+        @testset "$format" begin
 
-    # Test logging
-    # Note that logs won't display since they are captured by the test macro
-    qp = @test_logs(
-        # These logs must appear in exactly this order
-        (:info, "Using 'QP example' as NAME (l. 1)"),
-        (:info, "Using 'obj' as objective (l. 3)"),
-        (:info, "Using 'rhs1' as RHS (l. 12)"),
-        (:info, "Using 'bnd1' as BOUNDS (l. 16)"),
-        match_mode = :all,
-        readqps("dat/qp-example.qps")
-    )
+            # Test logging
+            # Note that logs won't display since they are captured by the test macro
+            qp = @test_logs(
+                # These logs must appear in exactly this order
+                (:info, "Using 'QPexample' as NAME (l. 1)"),
+                (:info, "Using 'obj' as objective (l. 3)"),
+                (:info, "Using 'rhs1' as RHS (l. 12)"),
+                (:info, "Using 'bnd1' as BOUNDS (l. 16)"),
+                match_mode = :all,
+                readqps("dat/qp-example.qps", mpsformat=format)
+            )
 
-    @test qp.name == "QP example"
-    @test qp.objname == "obj"
-    @test qp.rhsname == "rhs1"
-    @test qp.bndname == "bnd1"
-    @test qp.rngname === nothing
+            @test qp.name == "QPexample"
+            @test qp.objname == "obj"
+            @test qp.rhsname == "rhs1"
+            @test qp.bndname == "bnd1"
+            @test qp.rngname === nothing
 
-    @test qp.nvar == 2
-    @test qp.ncon == 2
-    @test qp.c0 == 4.0
-    @test all(qp.c .== [1.5, -2.0])
-    Q = sparse(qp.qrows, qp.qcols, qp.qvals, qp.nvar, qp.nvar)
-    A = sparse(qp.arows, qp.acols, qp.avals, qp.ncon, qp.nvar)
-    @test all(Matrix(Q) .== [8.0 0.0 ; 2.0 10.0])
-    @test all(Matrix(A) .== [2.0 1.0 ; -1.0 2.0])
-    @test all(qp.lcon .== [2.0, -Inf])
-    @test all(qp.ucon .== [Inf, 6.0])
-    @test all(qp.lvar .== [0.0, 0.0])
-    @test all(qp.uvar .== [20.0, Inf])
+            @test qp.nvar == 2
+            @test qp.ncon == 2
+            @test qp.c0 == 4.0
+            @test all(qp.c .== [1.5, -2.0])
+            Q = sparse(qp.qrows, qp.qcols, qp.qvals, qp.nvar, qp.nvar)
+            A = sparse(qp.arows, qp.acols, qp.avals, qp.ncon, qp.nvar)
+            @test all(Matrix(Q) .== [8.0 0.0 ; 2.0 10.0])
+            @test all(Matrix(A) .== [2.0 1.0 ; -1.0 2.0])
+            @test all(qp.lcon .== [2.0, -Inf])
+            @test all(qp.ucon .== [Inf, 6.0])
+            @test all(qp.lvar .== [0.0, 0.0])
+            @test all(qp.uvar .== [20.0, Inf])
 
-    @test qp.connames == ["r1", "r2"]
-    @test qp.varnames == ["c1", "c2"]
-    @test qp.varindices["c1"] == 1
-    @test qp.varindices["c2"] == 2
+            @test qp.connames == ["r1", "r2"]
+            @test qp.varnames == ["c1", "c2"]
+            @test qp.varindices["c1"] == 1
+            @test qp.varindices["c2"] == 2
+        end
+    end
 end

--- a/test/rimdata.jl
+++ b/test/rimdata.jl
@@ -1,93 +1,95 @@
 @testset "Rim data" begin
+    for format in [:fixed, :free]
+        @testset "$format" begin
+            @testset "Objective" begin
 
-    @testset "Objective" begin
+                qp = @test_logs(
+                    (:info, "Using 'RimObj' as NAME (l. 1)"),
+                    (:info, "Using 'obj1' as objective (l. 3)"),
+                    (:warn, "Detected rim objective row obj2 at line 4"),
+                    (:warn, "Detected rim objective row obj3 at line 7"),
+                    (:error, "Ignoring coefficient (obj2, c1) with value 2.2 at line 10"),
+                    (:error, "Ignoring coefficient (obj2, c2) with value -2.2 at line 12"),
+                    (:error, "Ignoring coefficient (obj3, c1) with value 2.3 at line 13"),
+                    (:error, "Ignoring coefficient (obj3, c2) with value -2.3 at line 14"),
+                    (:info, "Using 'rhs1' as RHS (l. 16)"),
+                    (:error, "Ignoring RHS for rim objective obj2 at line 16"),
+                    match_mode = :all,
+                    readqps("dat/rim_obj.qps")
+                )
 
-        qp = @test_logs(
-            (:info, "Using 'RimObj' as NAME (l. 1)"),
-            (:info, "Using 'obj1' as objective (l. 3)"),
-            (:warn, "Detected rim objective row obj2 at line 4"),
-            (:warn, "Detected rim objective row obj3 at line 7"),
-            (:error, "Ignoring coefficient (obj2, c1) with value 2.2 at line 10"),
-            (:error, "Ignoring coefficient (obj2, c2) with value -2.2 at line 12"),
-            (:error, "Ignoring coefficient (obj3, c1) with value 2.3 at line 13"),
-            (:error, "Ignoring coefficient (obj3, c2) with value -2.3 at line 14"),
-            (:info, "Using 'rhs1' as RHS (l. 16)"),
-            (:error, "Ignoring RHS for rim objective obj2 at line 16"),
-            match_mode = :all,
-            readqps("dat/rim_obj.qps")
-        )
+                @test qp.objname == "obj1"
+                @test qp.conindices["obj1"] == 0
+                @test qp.conindices["obj2"] == -1
+                @test qp.conindices["obj3"] == -1
 
-        @test qp.objname == "obj1"
-        @test qp.conindices["obj1"] == 0
-        @test qp.conindices["obj2"] == -1
-        @test qp.conindices["obj3"] == -1
+                @test qp.c0 == 4.1
 
-        @test qp.c0 == 4.1
+                @test qp.c == [1.5, -2.1]
+            end
 
-        @test qp.c == [1.5, -2.1]
-    end
+            @testset "Columns" begin
+            end
 
-    @testset "Columns" begin
-    end
+            @testset "QuadObj" begin
+            end
 
-    @testset "QuadObj" begin
-    end
+            @testset "RHS" begin
+                qp = @test_logs(
+                    # These logs should appear in exactly this order
+                    (:info, "Using 'RimRHS' as NAME (l. 1)"),
+                    (:info, "Using 'obj1' as objective (l. 3)"),
+                    (:info, "Using 'rhs1' as RHS (l. 12)"),
+                    (:error, "Skipping line 13 with rim RHS rhs2"),
+                    (:error, "Skipping line 15 with rim RHS rhs2"),
+                    (:error, "Skipping line 16 with rim RHS rhs3"),
+                    match_mode = :all,
+                    readqps("dat/rim_rhs.qps")
+                )
 
-    @testset "RHS" begin
-        qp = @test_logs(
-            # These logs should appear in exactly this order
-            (:info, "Using 'RimRHS' as NAME (l. 1)"),
-            (:info, "Using 'obj1' as objective (l. 3)"),
-            (:info, "Using 'rhs1' as RHS (l. 12)"),
-            (:error, "Skipping line 13 with rim RHS rhs2"),
-            (:error, "Skipping line 15 with rim RHS rhs2"),
-            (:error, "Skipping line 16 with rim RHS rhs3"),
-            match_mode = :all,
-            readqps("dat/rim_rhs.qps")
-        )
+                @test qp.rhsname == "rhs1"
 
-        @test qp.rhsname == "rhs1"
+                @test qp.c0 == 4.1
 
-        @test qp.c0 == 4.1
+                @test qp.lcon == [2.0, -Inf]
+                @test qp.ucon == [Inf, 6.0]
+            end
 
-        @test qp.lcon == [2.0, -Inf]
-        @test qp.ucon == [Inf, 6.0]
-    end
+            @testset "Range" begin
+                qp = @test_logs(
+                    # These logs should appear in exactly this order
+                    (:info, "Using 'RimRANGES' as NAME (l. 1)"),
+                    (:info, "Using 'obj1' as objective (l. 3)"),
+                    (:info, "Using 'rhs1' as RHS (l. 12)"),
+                    (:info, "Using 'rng1' as RANGES (l. 15)"),
+                    (:error, "Skipping line 16 with rim RANGES rng2"),
+                    match_mode = :all,
+                    readqps("dat/rim_rng.qps")
+                )
 
-    @testset "Range" begin
-        qp = @test_logs(
-            # These logs should appear in exactly this order
-            (:info, "Using 'RimRANGES' as NAME (l. 1)"),
-            (:info, "Using 'obj1' as objective (l. 3)"),
-            (:info, "Using 'rhs1' as RHS (l. 12)"),
-            (:info, "Using 'rng1' as RANGES (l. 15)"),
-            (:error, "Skipping line 16 with rim RANGES rng2"),
-            match_mode = :all,
-            readqps("dat/rim_rng.qps")
-        )
+                @test qp.rngname == "rng1"
 
-        @test qp.rngname == "rng1"
+                @test qp.lcon == [2.0, 3.9]
+                @test qp.ucon == [3.1, 6.0]
+            end
 
-        @test qp.lcon == [2.0, 3.9]
-        @test qp.ucon == [3.1, 6.0]
-    end
+            @testset "Bounds" begin
+                qp = @test_logs(
+                    # These logs should appear in exactly this order
+                    (:info, "Using 'RimBOUNDS' as NAME (l. 1)"),
+                    (:info, "Using 'obj' as objective (l. 3)"),
+                    (:info, "Using 'bnd1' as BOUNDS (l. 12)"),
+                    (:error, "Skipping line 13 with rim bound bnd2"),
+                    (:error, "Skipping line 15 with rim bound bnd2"),
+                    match_mode = :all,
+                    readqps("dat/rim_bnd.qps")
+                )
 
-    @testset "Bounds" begin
-        qp = @test_logs(
-            # These logs should appear in exactly this order
-            (:info, "Using 'RimBOUNDS' as NAME (l. 1)"),
-            (:info, "Using 'obj' as objective (l. 3)"),
-            (:info, "Using 'bnd1' as BOUNDS (l. 12)"),
-            (:error, "Skipping line 13 with rim bound bnd2"),
-            (:error, "Skipping line 15 with rim bound bnd2"),
-            match_mode = :all,
-            readqps("dat/rim_bnd.qps")
-        )
+                @test qp.bndname == "bnd1"
 
-        @test qp.bndname == "bnd1"
-
-        @test qp.lvar == [0.0, 1.0]
-        @test qp.uvar == [20.0, Inf]
-    end
-
-end
+                @test qp.lvar == [0.0, 1.0]
+                @test qp.uvar == [20.0, Inf]
+            end
+        end  # testset
+    end  # format loop
+end  # RimData testset


### PR DESCRIPTION
Adds support for parsing Free MPS format. Free MPS should cover almost all cases; the only limitation is that names should not contain any spaces.

A few points and questions:
* I expanded existing tests to run with both free and fixed format. Should we have more?
* Markers in the `COLUMNS` section (e.g., integrality markers) are ignored. An `@error` message is displayed though
* Currently, there is no automatic detection of whether the file is in fixed or free format. The format must be specified as a keyword argument to `readqps` (default value is `:fixed`).

