### PR TITLE
Minor bug fixes

### DIFF
--- a/test/parser.jl
+++ b/test/parser.jl
@@ -1,0 +1,93 @@
+import QPSReader:
+    MPSCard, FreeMPS, FixedMPS, read_card!
+
+function test_parser(card::MPSCard)
+    @testset "Comment line" begin test_parser_comment!(card) end
+
+    @testset "Header line" begin test_parser_header!(card) end
+
+    @testset "Regular line" begin test_parser_general!(card) end
+end
+
+function test_parser_comment!(card)
+    read_card!(card, "* This line is a comment")
+    @test card.iscomment
+    @test !card.isheader
+    @test card.nfields == 0
+
+    return
+end
+
+function test_parser_header!(card)
+    read_card!(card, "COLUMNS")
+    @test !card.iscomment
+    @test card.isheader
+    @test card.nfields == 1
+    @test card.f1 == "COLUMNS"
+
+    read_card!(card, "NAME          QPexample")
+    @test !card.iscomment
+    @test card.isheader
+    @test card.nfields == 2
+    @test card.f1 == "NAME"
+    @test card.f2 == "QPexample"
+
+    return
+end 
+
+function test_parser_general!(card)
+    # 2 fields
+    read_card!(card, " N  obj")
+    @test !card.iscomment
+    @test !card.isheader
+    @test card.nfields == 2
+    @test card.f1 == "N"
+    @test card.f2 == "obj"
+    # Same, but 3rd character is non-empty instead of 2nd
+    read_card!(card, "  N obj")
+    @test !card.iscomment
+    @test !card.isheader
+    @test card.nfields == 2
+    @test card.f1 == "N"
+    @test card.f2 == "obj"
+
+    # 3 fields (1st fixed field empty)
+    read_card!(card, "    rhs1       r1              -4.0")
+    @test !card.iscomment
+    @test !card.isheader
+    @test card.nfields == 3
+    @test card.f1 == "rhs1"
+    @test card.f2 == "r1"
+    @test card.f3 == "-4.0"
+
+    # 4 fields (1st fixed field non-empty)
+    read_card!(card, " UP  bnd1      c1               20.0")
+    @test !card.iscomment
+    @test !card.isheader
+    @test card.nfields == 4
+    @test card.f1 == "UP"
+    @test card.f2 == "bnd1"
+    @test card.f3 == "c1"
+    @test card.f4 == "20.0"
+
+    # 5 fields (1st fixed field empty)
+    read_card!(card, "    c1        r1                2.0    r2               -1.0")
+    @test !card.iscomment
+    @test !card.isheader
+    @test card.nfields == 5
+    @test card.f1 == "c1"
+    @test card.f2 == "r1"
+    @test card.f3 == "2.0"
+    @test card.f4 == "r2"
+    @test card.f5 == "-1.0"
+end
+
+@testset "Line parser" begin
+@testset "Fixed" begin
+    test_parser(MPSCard{FixedMPS}(0, false, false, 0, "", "", "", "", "", ""))
+end
+
+@testset "Free" begin
+test_parser(MPSCard{FreeMPS}(0, false, false, 0, "", "", "", "", "", ""))
+end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,6 @@ using Logging
 
 using QPSReader
 
+include("parser.jl")
 include("qp-example.jl")
 include("rimdata.jl")


### PR DESCRIPTION
This PR fixes two minor bugs. No breaking changes are made to the user-exposed functionalities.

### Parsing

There was a small bug when counting the number of fields in a line for Free MPS files.
In order to match the fields to the Fixed MPS format, the parser checked if the second character of the line was empty, in which case an artificial empty field was inserted. While doing so allowed to not change the rest of the code, it failed in the following case (which, incidentally, I never ran into for a while):
```
  N NOBJ
```
(note that the second character is a space, but the first fixed-length field is non-empty).

This would be parsed as follows:
* Fixed MPS: two fields: `f1 = "N"`, `f2 = "NOBJ"`
* Free MPS: _three_ fields: `f1 = ""`, `f2 = "N"`, `f3 = "NOBJ"`

Since, when handling a Free MPS file, it is actually not possible to know, from the line itself, whether an empty field should be inserted, I changed the parser so that only non-empty fields are recorded for both formats.
* Free MPS parser: no change
* Fixed MPS parser: if the first field is empty, it is removed and the number of fields is reduced by one


### Binary variables

An error is no longer thrown when encountering a binary marker (`BV`) in the bounds section.
Instead, a warning is displayed (similar to what is done for `UI` and `LI` bounds) and the variable's lower and upper bound are set to `0` and `1`, respectively.