### PR TITLE
Update benchmark scripts

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,5 +1,3 @@
 Manifest.toml
-netlib/
-maros/
 *.json
 *.md

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 QPSReader = "10f199a5-22af-520b-b891-7ce84a7b1bd0"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,52 +2,23 @@
 
 ## Benchmark testsets
 
-### Netlib
-
-The netlib testset contains 114 small LP instances.
-It is available [here](http://www.numerical.rl.ac.uk/cute/netlib.html) (in `.SIF` format)
-
-To download and extract (on Linux systems) the netlib LPs:
-```bash
-# Download dataset
-wget ftp://ftp.numerical.rl.ac.uk/pub/cuter/netlib.tar.gz
-# Extract instances
-tar -xvf netlib.tar.gz
-# Delete files that are not instances
-find netlib -type f ! -name "*.SIF" -delete
-```
-
-### Maros-Meszaros QPs
-
-The Maros-Meszaros QPs can be found [here](http://www.doc.ic.ac.uk/~im/#DATA).
-The three datasets total 138 QPs.
-
-To download the datasets (on Linux systems):
-```bash
-# Download datasets
-wget http://www.doc.ic.ac.uk/%7Eim/QPDATA1.ZIP
-wget http://www.doc.ic.ac.uk/%7Eim/QPDATA2.ZIP
-wget http://www.doc.ic.ac.uk/%7Eim/QPDATA3.ZIP
-# Extract datasets
-mkdir maros
-unzip -q QPDATA1.ZIP -d maros
-unzip -q QPDATA2.ZIP -d maros
-unzip -q QPDATA3.ZIP -d maros
-```
+Benchmarks are run on the [Netlib LP collection](http://www.numerical.rl.ac.uk/cute/netlib.html) and [Maros-Meszaros QP collection](http://www.doc.ic.ac.uk/~im/#DATA).
+They consist of 114 LPs and 138 QPs, respectively.
+Both collections are automatically through Julia's artifact system.
 
 ## Running the benchmark
 
 Ensure that your current `Manifest.toml` points to the correct version of `QPSReader`. Otherwise, the most recent version will be installed.
-```bash
+```julia
 Pkg.develop(PackageSpec(path=".."))
 ```
 
 Then, run the benchmark as follows:
 ```julia
-julia> using PkgBenchmark
-julia> import QPSReader
-julia> res = benchmarkpkg(pathof(QPSReader));
-julia> export_markdown("results.md", res)
+using PkgBenchmark
+import QPSReader
+res = benchmarkpkg(pathof(QPSReader));
+export_markdown("results.md", res)
 ```
 
 ## Comparing two commits
@@ -55,6 +26,7 @@ julia> export_markdown("results.md", res)
 To compare against the `master` branch
 ```julia
 using PkgBenchmark
+
 judgement = judge("..", "master")
 export_markdown("judgement.md", judgement)
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,7 @@
 
 Benchmarks are run on the [Netlib LP collection](http://www.numerical.rl.ac.uk/cute/netlib.html) and [Maros-Meszaros QP collection](http://www.doc.ic.ac.uk/~im/#DATA).
 They consist of 114 LPs and 138 QPs, respectively.
-Both collections are automatically through Julia's artifact system.
+Both collections are automatically downloaded through Julia's artifact system.
 
 ## Running the benchmark
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -46,7 +46,7 @@ function add_instances!(suite, dir)
         try
             # First try to read in free MPS format.
             # If fails, try with fixed MPS format
-            # If fails again, abort
+            # If fails again, discard instance
             try
                 readqps_silent(fpath)
                 suite[finst] = @benchmarkable(readqps_silent($fpath))


### PR DESCRIPTION
The main modifications are as follows:
* The Netlib and Maros-Meszaros collections do not need to be downloaded manually, we use the ones from the artifacts.
* Log information is suppressed during the benchmark
* Each instance is first read in free MPS format. If this errors, the fixed MPS format is tried. If fixed format also errors, the instance is discarded from the benchmark. Discarded instances are shown in a warning before the benchmark starts. 

Running the entire benchmark takes roughly 45min : ~250 instances x (5s tune + 5s benchmark) = ~2,500s.
FWIW, reading all instances from either collection takes around 6s.
