### PR TITLE
Support integer variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The problems represented by the QPS format have the form
 optimize &nbsp; c₀ + cᵀ x + ½ xᵀ Q x
 &nbsp;&nbsp;
 subject to &nbsp; L ≤ Ax ≤ U and ℓ ≤ x ≤ u,
+
 </p>
 
 where:
@@ -24,8 +25,7 @@ where:
 * `A` is the *m×n* constraint matrix, `L`, `U` are constraint lower and upper bounds, respectively
 * `ℓ`, `u` are variable lower and upper bounds, respectively
 
-Only continuous problems are supported at this time.
-Integer and semi-continuous markers will be ignored.
+Mixed-integer problems are supported, but semi-continuous and semi-integer variables are not.
 
 ## Quick start
 
@@ -106,12 +106,20 @@ mutable struct QPSData
     # Rim objective rows have index -1
     conindices::Dict{String, Int}
 
+    # Variable types
+    #  'C'  <--> continuous
+    #  'I'  <--> integer
+    #  'B'  <--> binary
+    #  'S'  <--> semi-continuous (not supported)
+    #  'N'  <--> semi-integer (not supported)
+    vartypes::Vector{Char}
+
     # Indicates the sense of each row:
-    #   0  <--> E
-    #  -1  <--> L
-    #   1  <--> G
-    #   2  <--> N
-    contypes::Vector{Int}
+    #  'E'  <--> equality constraint
+    #  'L'  <--> less-than-or-equal-to
+    #  'G'  <--> greater-than-or-equal-to
+    #  'N'  <--> objective
+    contypes::Vector{Char}
 end
 ```
 Rows and variables are indexed in the order in which they are read.
@@ -125,6 +133,8 @@ The file formats supported by `QPSReader` are described here:
 
 The following conventions are enforced:
 
+### Rim data
+
 * Multiple objective rows
     * The first `N`-type row encountered in the `ROWS` section is recorded as the objective function, and its name is stored in `objname`.
     * If an additional `N`-type row is present, a `warning`-level log is displayed. Subsequent `N`-type rows are ignored.
@@ -136,13 +146,43 @@ The following conventions are enforced:
     A `warning`-level log is displayed at the first such occurence.
     * In addition, any line or individual coefficient that is ignored triggers an `error`-level log.
 
+### Variable bounds
+
+* Default bounds for variables are `[0, Inf)`, to exception of integer variables (see below).
+* If multiple bounds are specified for a given variable, only the most recent bound is recorded.
+
+### Integer variables
+
+There are two ways of declaring integer variables:
+
+* Through markers in the `COLUMNS` section.
+* By specifying `BV`, `LI` or `UI` bounds in the `BOUNDS` section
+* The convention for integer variable bounds in as follows:
+    | Marker? | `BOUNDS` fields | Type | Bounds reported |
+    |:--:|:--:|:--:|:--:|
+    | Yes | - | Integer | `[0, 1]` 
+    | Yes | `BV` | Binary | `[0, 1]` 
+    | Yes | (`LI`, `l`) | Integer | `[l, Inf]` 
+    | Yes | (`UI`, `u`) with `u≥0` | Integer | `[0, u]`
+    | Yes | (`UI`, `u`) with `u<0` | Integer | `[-Inf, u]`
+    | Yes | (`LI`, `l`) + (`UI`, `u`) | Integer | `[l, u]` 
+    | No | `BV` | Binary | `[0, 1]` 
+    | No | (`LI`, `l`) | Integer | `[l, Inf]` 
+    | No | (`UI`, `u`) with `u≥0` | Integer | `[0, u]`
+    | No | (`UI`, `u`) with `u<0` | Integer | `[-Inf, u]`
+    | No | (`LI`, `l`) + (`UI`, `u`) | Integer | `[l, u]` 
+
+    The `LI`/`UI` can be replaced by `LO`/`UP` in the table above, with no impact on bounds. Only the integrality of variables are affected.
+    For continuous variables, follow the second half of the table, and replace `LI`/`UI` by `LO`/`UP`.
+
+### Errors
+
 * A row (resp. column) name that was not declared in the `ROWS` (resp. `COLUMNS`) section, appears elsewhere in the file.
 The only case where an error is not thrown is if said un-declared row or column appears in a rim line that is skipped.
 * An `N`-type row appears in the `RANGES` section
 
 
 ## Problem Collections
-
 
 * The Netlib LPs: [original Netlib site](http://www.netlib.org/lp) | [in SIF format](http://www.numerical.rl.ac.uk/cute/netlib.html) | [as tar files](http://users.clas.ufl.edu/hager/coap/format.html) (incl. preprocessed versions)
 * the Kennington LPs: [original Netlib site](http://www.netlib.org/lp/data/kennington)

--- a/README.md
+++ b/README.md
@@ -107,19 +107,19 @@ mutable struct QPSData
     conindices::Dict{String, Int}
 
     # Variable types
-    #  :Continuous      <--> continuous
-    #  :Integer         <--> integer
-    #  :Binary          <--> binary
-    #  :SemiContinuous  <--> semi-continuous (not supported)
-    #  :SemiInteger     <--> semi-integer (not supported)
-    vartypes::Vector{Symbol}
+    #  `VTYPE_Continuous`      <--> continuous
+    #  `VTYPE_Integer`         <--> integer
+    #  `VTYPE_Binary`          <--> binary
+    #  `VTYPE_SemiContinuous`  <--> semi-continuous (not supported)
+    #  `VTYPE_SemiInteger`     <--> semi-integer (not supported)
+    vartypes::Vector{VariableType}
 
     # Indicates the sense of each row:
-    #  :EqualTo      <--> equality constraint
-    #  :LessThan     <--> less-than-or-equal-to
-    #  :GreaterThan  <--> greater-than-or-equal-to
-    #  :Objective    <--> objective
-    contypes::Vector{Symbol}
+    # `RTYPE_Objective`    <--> objective row (`'N'`)
+    # `RTYPE_EqualTo`      <--> equality constraint (`'E'`)
+    # `RTYPE_LessThan`     <--> less-than constraint (`'L'`)
+    # `RTYPE_GreaterThan`  <--> greater-than constraint (`'G'`)
+    contypes::Vector{RowType}
 end
 ```
 Rows and variables are indexed in the order in which they are read.

--- a/README.md
+++ b/README.md
@@ -107,19 +107,19 @@ mutable struct QPSData
     conindices::Dict{String, Int}
 
     # Variable types
-    #  'C'  <--> continuous
-    #  'I'  <--> integer
-    #  'B'  <--> binary
-    #  'S'  <--> semi-continuous (not supported)
-    #  'N'  <--> semi-integer (not supported)
-    vartypes::Vector{Char}
+    #  :Continuous      <--> continuous
+    #  :Integer         <--> integer
+    #  :Binary          <--> binary
+    #  :SemiContinuous  <--> semi-continuous (not supported)
+    #  :SemiInteger     <--> semi-integer (not supported)
+    vartypes::Vector{Symbol}
 
     # Indicates the sense of each row:
-    #  'E'  <--> equality constraint
-    #  'L'  <--> less-than-or-equal-to
-    #  'G'  <--> greater-than-or-equal-to
-    #  'N'  <--> objective
-    contypes::Vector{Char}
+    #  :EqualTo      <--> equality constraint
+    #  :LessThan     <--> less-than-or-equal-to
+    #  :GreaterThan  <--> greater-than-or-equal-to
+    #  :Objective    <--> objective
+    contypes::Vector{Symbol}
 end
 ```
 Rows and variables are indexed in the order in which they are read.

--- a/src/readqps.jl
+++ b/src/readqps.jl
@@ -35,7 +35,7 @@ mutable struct QPSData
     # Rim objective rows have index -1
     conindices::Dict{String, Int}
     # Variable types
-    vartypes::Vector{Int}
+    vartypes::Vector{Char}
     # Constraint types (senses)
     contypes::Vector{Int}
 end
@@ -128,12 +128,12 @@ function row_type(rtype::String)
 end
 
 # Variable types
-const VTYPE_M = -1  # Marked integer
-const VTYPE_C =  0  # Continuous variable
-const VTYPE_B =  1  # Binary variable
-const VTYPE_I =  2  # Integer variable
-const VTYPE_S =  3  # Semi-continuous
-const VTYPE_N =  4  # Semi-integer
+const VTYPE_M = 'M'  # Marked integer (for internal use)
+const VTYPE_C = 'C'  # Continuous variable
+const VTYPE_B = 'B'  # Binary variable
+const VTYPE_I = 'I'  # Integer variable
+const VTYPE_S = 'S'  # Semi-continuous
+const VTYPE_N = 'N'  # Semi-integer
 
 """
     read_card!(card::MPSCard{FixedMPS}, ln::String)
@@ -844,6 +844,7 @@ function readqps(qps::IO; mpsformat::Symbol=:free)
             qpsdat.lvar[j] = 0.0
             qpsdat.uvar[j] = (vt == VTYPE_M) ? 1.0 : Inf
         elseif isnan(l) && !isnan(u)
+            # Only an upper bound was specified
             # Set lower bound to zero, unless upper bound is negative
             if u < 0
                 qpsdat.lvar[j] = -Inf
@@ -851,14 +852,14 @@ function readqps(qps::IO; mpsformat::Symbol=:free)
                 qpsdat.lvar[j] = 0.0
             end
         elseif !isnan(l) && isnan(u)
+            # Only a lower bound was specified
             # Set default upper bound
-            qpsdat.uvar[j] = (vt == VTYPE_M) ? 1.0 : Inf
+            qpsdat.uvar[j] = Inf
         end
 
         # Set correct variable type
         if vt == VTYPE_M
             qpsdat.vartypes[j] = VTYPE_I
-            qpsdat.uvar[j] = 1.0
         end
     end
 

--- a/src/readqps.jl
+++ b/src/readqps.jl
@@ -37,7 +37,7 @@ mutable struct QPSData
     # Variable types
     vartypes::Vector{Char}
     # Constraint types (senses)
-    contypes::Vector{Int}
+    contypes::Vector{Char}
 end
 
 abstract type MPSFormat end
@@ -108,10 +108,10 @@ function section_header(s::String)
 end
 
 # Row types
-const RTYPE_E =  0  # equal-to
-const RTYPE_L = -1  # less-than
-const RTYPE_G =  1  # greater-than
-const RTYPE_N =  2  # objective
+const RTYPE_E = 'E'  # equal-to
+const RTYPE_L = 'L'  # less-than
+const RTYPE_G = 'G'  # greater-than
+const RTYPE_N = 'N'  # objective
 
 function row_type(rtype::String)
     if rtype == "E"

--- a/src/readqps.jl
+++ b/src/readqps.jl
@@ -35,9 +35,9 @@ mutable struct QPSData
     # Rim objective rows have index -1
     conindices::Dict{String, Int}
     # Variable types
-    vartypes::Vector{Char}
+    vartypes::Vector{Symbol}
     # Constraint types (senses)
-    contypes::Vector{Char}
+    contypes::Vector{Symbol}
 end
 
 abstract type MPSFormat end
@@ -108,10 +108,10 @@ function section_header(s::String)
 end
 
 # Row types
-const RTYPE_E = 'E'  # equal-to
-const RTYPE_L = 'L'  # less-than
-const RTYPE_G = 'G'  # greater-than
-const RTYPE_N = 'N'  # objective
+const RTYPE_E = :EqualTo      # equal-to
+const RTYPE_L = :LessThan     # less-than
+const RTYPE_G = :GreaterThan  # greater-than
+const RTYPE_N = :Objective    # objective
 
 function row_type(rtype::String)
     if rtype == "E"
@@ -128,12 +128,12 @@ function row_type(rtype::String)
 end
 
 # Variable types
-const VTYPE_M = 'M'  # Marked integer (for internal use)
-const VTYPE_C = 'C'  # Continuous variable
-const VTYPE_B = 'B'  # Binary variable
-const VTYPE_I = 'I'  # Integer variable
-const VTYPE_S = 'S'  # Semi-continuous
-const VTYPE_N = 'N'  # Semi-integer
+const VTYPE_M = :Marked          # Marked integer (for internal use)
+const VTYPE_C = :Continuous      # Continuous variable
+const VTYPE_B = :Binary          # Binary variable
+const VTYPE_I = :Integer         # Integer variable
+const VTYPE_S = :SemiContinuous  # Semi-continuous
+const VTYPE_N = :SemiInteger     # Semi-integer
 
 """
     read_card!(card::MPSCard{FixedMPS}, ln::String)

--- a/test/dat/milp.mps
+++ b/test/dat/milp.mps
@@ -1,0 +1,26 @@
+NAME          MILP
+ROWS
+ N  obj
+COLUMNS
+    x1        obj                1.0
+    MARK0000  'MARKER'     'INTORG'
+    x2        obj                2.0
+    x3        obj                3.0
+    x4        obj                4.0
+    x5        obj                5.0
+    x6        obj                6.0
+    MARK0001  'MARKER'     'INTEND'
+    x7        obj                7.0
+    x8        obj                8.0
+    x9        obj                9.0
+    x10       obj               10.0
+BOUNDS
+ BV  bnd       x3                0.0
+ LI  bnd       x4               -4.0
+ UI  bnd       x5                5.0
+ LI  bnd       x6               -6.0
+ UI  bnd       x6                6.0
+ BV  bnd       x7                7.0
+ LI  bnd       x8               -8.0
+ UI  bnd       x9                9.0
+ENDATA

--- a/test/dat/milp.mps
+++ b/test/dat/milp.mps
@@ -9,19 +9,35 @@ COLUMNS
     x4        obj                4.0
     x5        obj                5.0
     x6        obj                6.0
-    MARK0001  'MARKER'     'INTEND'
     x7        obj                7.0
     x8        obj                8.0
     x9        obj                9.0
     x10       obj               10.0
+    x11       obj               11.0
+    MARK0001  'MARKER'     'INTEND'
+    x12       obj               12.0
+    x13       obj               13.0
+    x14       obj               14.0
+    x15       obj               15.0
+    x16       obj               16.0
+    x17       obj               17.0
 BOUNDS
  BV  bnd       x3                0.0
  LI  bnd       x4               -4.0
  UI  bnd       x5                5.0
- LI  bnd       x6               -6.0
- UI  bnd       x6                6.0
- BV  bnd       x7                7.0
- LI  bnd       x8               -8.0
- UI  bnd       x9                9.0
- UP  bnd      x10               -1.0
+ UI  bnd       x6               -6.0
+ LI  bnd       x7               -7.0
+ UI  bnd       x7                7.0
+ LO  bnd       x8               -8.0
+ UP  bnd       x9                9.0
+ UP  bnd       x10             -10.0
+ LO  bnd       x11             -11.0
+ UP  bnd       x11              11.0
+ BV  bnd       x12               0.0
+ LI  bnd       x13             -13.0
+ UI  bnd       x14              14.0
+ UI  bnd       x15             -15.0
+ LI  bnd       x16             -16.0
+ UI  bnd       x16              16.0
+ UP  bnd       x17             -17.0
 ENDATA

--- a/test/dat/milp.mps
+++ b/test/dat/milp.mps
@@ -23,4 +23,5 @@ BOUNDS
  BV  bnd       x7                7.0
  LI  bnd       x8               -8.0
  UI  bnd       x9                9.0
+ UP  bnd      x10               -1.0
 ENDATA

--- a/test/integers.jl
+++ b/test/integers.jl
@@ -14,7 +14,7 @@
     @test milp.vartypes[7]  == QPSReader.VTYPE_B  # no marker + BV
     @test milp.vartypes[8]  == QPSReader.VTYPE_I  # no marker + LI
     @test milp.vartypes[9]  == QPSReader.VTYPE_I  # no marker + UI
-    @test milp.vartypes[10] == QPSReader.VTYPE_C  # no marker
+    @test milp.vartypes[10] == QPSReader.VTYPE_C  # no marker + UP of -1
 
     # Test bounds values
     @test (milp.lvar[1],  milp.uvar[1])  == (0.0,  Inf)
@@ -26,7 +26,7 @@
     @test (milp.lvar[7],  milp.uvar[7])  == (0.0,  1.0)
     @test (milp.lvar[8],  milp.uvar[8])  == (-8.0, Inf)
     @test (milp.lvar[9],  milp.uvar[9])  == (0.0,  9.0)
-    @test (milp.lvar[10], milp.uvar[10]) == (0.0,  Inf)
+    @test (milp.lvar[10], milp.uvar[10]) == (-Inf, -1.0)
 
 end
 end

--- a/test/integers.jl
+++ b/test/integers.jl
@@ -5,23 +5,23 @@
         readqps("dat/milp.mps", mpsformat=format)
     end
 
-    @test milp.vartypes[1]  == QPSReader.VTYPE_C  # no marker
-    @test milp.vartypes[2]  == QPSReader.VTYPE_I  # marker + no bounds
-    @test milp.vartypes[3]  == QPSReader.VTYPE_B  # marker + binary bound
-    @test milp.vartypes[4]  == QPSReader.VTYPE_I  # marker + LI
-    @test milp.vartypes[5]  == QPSReader.VTYPE_I  # marker + UI (>0)
-    @test milp.vartypes[6]  == QPSReader.VTYPE_I  # marker + UI (<0)
-    @test milp.vartypes[7]  == QPSReader.VTYPE_I  # marker + LI + UI
-    @test milp.vartypes[8]  == QPSReader.VTYPE_I  # marker + LO
-    @test milp.vartypes[9]  == QPSReader.VTYPE_I  # marker + UP (>0)
-    @test milp.vartypes[10] == QPSReader.VTYPE_I  # marker + UP (<0)
-    @test milp.vartypes[11] == QPSReader.VTYPE_I  # marker + LO + UP
-    @test milp.vartypes[12] == QPSReader.VTYPE_B  # no marker + BV
-    @test milp.vartypes[13] == QPSReader.VTYPE_I  # no marker + LI
-    @test milp.vartypes[14] == QPSReader.VTYPE_I  # no marker + UI (>0)
-    @test milp.vartypes[15] == QPSReader.VTYPE_I  # no marker + UI (<0)
-    @test milp.vartypes[16] == QPSReader.VTYPE_I  # no marker + LI + UI
-    @test milp.vartypes[17] == QPSReader.VTYPE_C  # no marker + UP (<0)
+    @test milp.vartypes[1]  == QPSReader.VTYPE_Continuous  # no marker
+    @test milp.vartypes[2]  == QPSReader.VTYPE_Integer  # marker + no bounds
+    @test milp.vartypes[3]  == QPSReader.VTYPE_Binary  # marker + binary bound
+    @test milp.vartypes[4]  == QPSReader.VTYPE_Integer  # marker + LI
+    @test milp.vartypes[5]  == QPSReader.VTYPE_Integer  # marker + UI (>0)
+    @test milp.vartypes[6]  == QPSReader.VTYPE_Integer  # marker + UI (<0)
+    @test milp.vartypes[7]  == QPSReader.VTYPE_Integer  # marker + LI + UI
+    @test milp.vartypes[8]  == QPSReader.VTYPE_Integer  # marker + LO
+    @test milp.vartypes[9]  == QPSReader.VTYPE_Integer  # marker + UP (>0)
+    @test milp.vartypes[10] == QPSReader.VTYPE_Integer  # marker + UP (<0)
+    @test milp.vartypes[11] == QPSReader.VTYPE_Integer  # marker + LO + UP
+    @test milp.vartypes[12] == QPSReader.VTYPE_Binary  # no marker + BV
+    @test milp.vartypes[13] == QPSReader.VTYPE_Integer  # no marker + LI
+    @test milp.vartypes[14] == QPSReader.VTYPE_Integer  # no marker + UI (>0)
+    @test milp.vartypes[15] == QPSReader.VTYPE_Integer  # no marker + UI (<0)
+    @test milp.vartypes[16] == QPSReader.VTYPE_Integer  # no marker + LI + UI
+    @test milp.vartypes[17] == QPSReader.VTYPE_Continuous  # no marker + UP (<0)
 
     # Test bounds values
     @test (milp.lvar[1],  milp.uvar[1])  == (0.0,  Inf)

--- a/test/integers.jl
+++ b/test/integers.jl
@@ -9,12 +9,19 @@
     @test milp.vartypes[2]  == QPSReader.VTYPE_I  # marker + no bounds
     @test milp.vartypes[3]  == QPSReader.VTYPE_B  # marker + binary bound
     @test milp.vartypes[4]  == QPSReader.VTYPE_I  # marker + LI
-    @test milp.vartypes[5]  == QPSReader.VTYPE_I  # marker + UI
-    @test milp.vartypes[6]  == QPSReader.VTYPE_I  # marker + LI + UI
-    @test milp.vartypes[7]  == QPSReader.VTYPE_B  # no marker + BV
-    @test milp.vartypes[8]  == QPSReader.VTYPE_I  # no marker + LI
-    @test milp.vartypes[9]  == QPSReader.VTYPE_I  # no marker + UI
-    @test milp.vartypes[10] == QPSReader.VTYPE_C  # no marker + UP of -1
+    @test milp.vartypes[5]  == QPSReader.VTYPE_I  # marker + UI (>0)
+    @test milp.vartypes[6]  == QPSReader.VTYPE_I  # marker + UI (<0)
+    @test milp.vartypes[7]  == QPSReader.VTYPE_I  # marker + LI + UI
+    @test milp.vartypes[8]  == QPSReader.VTYPE_I  # marker + LO
+    @test milp.vartypes[9]  == QPSReader.VTYPE_I  # marker + UP (>0)
+    @test milp.vartypes[10] == QPSReader.VTYPE_I  # marker + UP (<0)
+    @test milp.vartypes[11] == QPSReader.VTYPE_I  # marker + LO + UP
+    @test milp.vartypes[12] == QPSReader.VTYPE_B  # no marker + BV
+    @test milp.vartypes[13] == QPSReader.VTYPE_I  # no marker + LI
+    @test milp.vartypes[14] == QPSReader.VTYPE_I  # no marker + UI (>0)
+    @test milp.vartypes[15] == QPSReader.VTYPE_I  # no marker + UI (<0)
+    @test milp.vartypes[16] == QPSReader.VTYPE_I  # no marker + LI + UI
+    @test milp.vartypes[17] == QPSReader.VTYPE_C  # no marker + UP (<0)
 
     # Test bounds values
     @test (milp.lvar[1],  milp.uvar[1])  == (0.0,  Inf)
@@ -22,11 +29,18 @@
     @test (milp.lvar[3],  milp.uvar[3])  == (0.0,  1.0)
     @test (milp.lvar[4],  milp.uvar[4])  == (-4.0, Inf)
     @test (milp.lvar[5],  milp.uvar[5])  == (0.0,  5.0)
-    @test (milp.lvar[6],  milp.uvar[6])  == (-6.0, 6.0)
-    @test (milp.lvar[7],  milp.uvar[7])  == (0.0,  1.0)
+    @test (milp.lvar[6],  milp.uvar[6])  == (-Inf, -6.0)
+    @test (milp.lvar[7],  milp.uvar[7])  == (-7.0,  7.0)
     @test (milp.lvar[8],  milp.uvar[8])  == (-8.0, Inf)
     @test (milp.lvar[9],  milp.uvar[9])  == (0.0,  9.0)
-    @test (milp.lvar[10], milp.uvar[10]) == (-Inf, -1.0)
+    @test (milp.lvar[10], milp.uvar[10]) == (-Inf, -10.0)
+    @test (milp.lvar[11], milp.uvar[11]) == (-11.0, 11.0)
+    @test (milp.lvar[12], milp.uvar[12]) == (0.0, 1.0)
+    @test (milp.lvar[13], milp.uvar[13]) == (-13.0, Inf)
+    @test (milp.lvar[14], milp.uvar[14]) == (0.0, 14.0)
+    @test (milp.lvar[15], milp.uvar[15]) == (-Inf, -15.0)
+    @test (milp.lvar[16], milp.uvar[16]) == (-16.0, 16.0)
+    @test (milp.lvar[17], milp.uvar[17]) == (-Inf, -17.0)
 
 end
 end

--- a/test/integers.jl
+++ b/test/integers.jl
@@ -1,0 +1,32 @@
+@testset "Integers" begin
+@testset "$format" for format in [:fixed, :free]
+
+    milp = with_logger(Logging.NullLogger()) do
+        readqps("dat/milp.mps", mpsformat=format)
+    end
+
+    @test milp.vartypes[1]  == QPSReader.VTYPE_C  # no marker
+    @test milp.vartypes[2]  == QPSReader.VTYPE_I  # marker + no bounds
+    @test milp.vartypes[3]  == QPSReader.VTYPE_B  # marker + binary bound
+    @test milp.vartypes[4]  == QPSReader.VTYPE_I  # marker + LI
+    @test milp.vartypes[5]  == QPSReader.VTYPE_I  # marker + UI
+    @test milp.vartypes[6]  == QPSReader.VTYPE_I  # marker + LI + UI
+    @test milp.vartypes[7]  == QPSReader.VTYPE_B  # no marker + BV
+    @test milp.vartypes[8]  == QPSReader.VTYPE_I  # no marker + LI
+    @test milp.vartypes[9]  == QPSReader.VTYPE_I  # no marker + UI
+    @test milp.vartypes[10] == QPSReader.VTYPE_C  # no marker
+
+    # Test bounds values
+    @test (milp.lvar[1],  milp.uvar[1])  == (0.0,  Inf)
+    @test (milp.lvar[2],  milp.uvar[2])  == (0.0,  1.0)
+    @test (milp.lvar[3],  milp.uvar[3])  == (0.0,  1.0)
+    @test (milp.lvar[4],  milp.uvar[4])  == (-4.0, Inf)
+    @test (milp.lvar[5],  milp.uvar[5])  == (0.0,  5.0)
+    @test (milp.lvar[6],  milp.uvar[6])  == (-6.0, 6.0)
+    @test (milp.lvar[7],  milp.uvar[7])  == (0.0,  1.0)
+    @test (milp.lvar[8],  milp.uvar[8])  == (-8.0, Inf)
+    @test (milp.lvar[9],  milp.uvar[9])  == (0.0,  9.0)
+    @test (milp.lvar[10], milp.uvar[10]) == (0.0,  Inf)
+
+end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,4 @@ end
 include("parser.jl")
 include("qp-example.jl")
 include("rimdata.jl")
-
+include("integers.jl")


### PR DESCRIPTION
Addresses #28.

Summary of changes:
* `QPSData` now has a `vartypes` field that contains the type of each variable
* Integer markers are checked