### PR TITLE
add QMATRIX

### DIFF
--- a/src/readqps.jl
+++ b/src/readqps.jl
@@ -177,6 +177,7 @@ const SECTION_HEADERS = Dict{String, Int}(
   "BOUNDS" => BOUNDS,
   "RANGES" => RANGES,
   "QUADOBJ" => QUADOBJ,
+  "QMATRIX" => QUADOBJ,
   "OBJECT BOUND" => OBJECT_BOUND,  # SIF only
 )
 


### PR DESCRIPTION
Some mps files (including the mps files exported by CPLEX) use the field `QMATRIX`