### PR TITLE
New Feature:  Quadratic Constraints (QC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A package to read linear optimization problems in MPS format and quadratic optim
 
 If you use QPSReader.jl in your work, please cite using the format given in [CITATION.bib](https://github.com/JuliaSmoothOptimizers/QPSReader.jl/blob/main/CITATION.bib).
 
-The problems represented by the QCP format have the form
+The problems represented by the `.QPS`/`.mps` format have the form
 
 <p align="center">
 optimize &nbsp; c₀ + cᵀ x + ½ xᵀ Q₀ x

--- a/README.md
+++ b/README.md
@@ -13,20 +13,22 @@ A package to read linear optimization problems in MPS format and quadratic optim
 
 If you use QPSReader.jl in your work, please cite using the format given in [CITATION.bib](https://github.com/JuliaSmoothOptimizers/QPSReader.jl/blob/main/CITATION.bib).
 
-The problems represented by the QPS format have the form
+The problems represented by the QCP format have the form
 
 <p align="center">
-optimize &nbsp; c₀ + cᵀ x + ½ xᵀ Q x
+optimize &nbsp; c₀ + cᵀ x + ½ xᵀ Q₀ x
 &nbsp;&nbsp;
-subject to &nbsp; L ≤ Ax ≤ U and ℓ ≤ x ≤ u,
-
+subject to &nbsp; Lᵢ ≤ aᵢᵀ x + xᵀ Qᵢ x ≤ Uᵢ &nbsp; and &nbsp; ℓ ≤ x ≤ u,
 </p>
 
 where:
 * "optimize" means either "minimize" or "maximize"
-* `c₀` ∈ ℝ is a constant term, `c` ∈ ℝⁿ is the linear term, `Q = Qᵀ` is the *n×n* quadratic term,
-* `A` is the *m×n* constraint matrix, `L`, `U` are constraint lower and upper bounds, respectively
-* `ℓ`, `u` are variable lower and upper bounds, respectively
+* `c₀` ∈ ℝ is a constant term, `c` ∈ ℝⁿ is the linear term, `Q₀ = Q₀ᵀ` is the *n×n* objective quadratic term,
+* `aᵢ` is the *i*-th row of the constraint matrix, `Qᵢ = Qᵢᵀ` is the *n×n* quadratic term for constraint *i*,
+* `L`, `U` ∈ ℝᵐ are constraint lower and upper bounds, respectively
+* `ℓ`, `u` ∈ ℝⁿ are variable lower and upper bounds, respectively
+
+Mixed-integer problems are supported, but semi-continuous and semi-integer variables are not.
 
 Mixed-integer problems are supported, but semi-continuous and semi-integer variables are not.
 
@@ -86,6 +88,9 @@ mutable struct QPSData
     arows::Vector{Int}
     acols::Vector{Int}
     avals::Vector{Float64}
+
+    # Quadratic Constraints Data
+    qcdata::Dict{Int, Tuple{Vector{Int}, Vector{Int}, Vector{Float64}}}
 
     lcon::Vector{Float64}            # constraints lower bounds
     ucon::Vector{Float64}            # constraints upper bounds


### PR DESCRIPTION

### 🚀 Summary of Changes

This pull request introduces support for **Quadratic Constraints (QC)** in the `.QPS`/`.mps` file format, extending the package's capability from Quadratic Programming (QP) to Quadratically Constrained Quadratic Programming (QCQP).

This enhancement allows users to define constraints of the form $L_i \le a_i^\top x + x^\top Q_i x \le U_i$.

### ✨ Key Features and Updates

* **QCQP Support:** The core problem representation has been updated to include quadratic constraints.
* **New Data Structure:** `QPSData` now includes the `qcdata` field (`Dict{Int, Tuple{Vector{Int}, Vector{Int}, Vector{Float64}}}`) to store the constraint-specific quadratic terms ($Q_i$).
* **QCMATRIX Section Parsing:** Implements logic to correctly identify and parse data within the new `QCMATRIX` section header in the `.QPS`/`.mps` file.
* **Documentation Update:** The `README.md` has been revised to reflect the new, more general problem format (including $Q_0$ for the objective and $Q_i$ for constraints).

### 📖 Updated Problem Format (README.md)

The problem format now officially supported is:

$$\text{optimize} \quad c_0 + c^\top x + \frac{1}{2} x^\top Q_0 x$$
$$\text{subject to} \quad L_i \le a_i^\top x + x^\top Q_i x \le U_i \quad \text{and} \quad \ell \le x \le u$$

### 🛠️ Implementation Details

* **`src/readqps.jl`:**
    * Added `const QCMATRIX = 11` to section headers.
    * Updated `read_card!` to recognize and handle the `QCMATRIX` section, which requires a row name (`card.f2`).
    * Implemented `read_qcmatrix_line!` to process the variable indices and values for the quadratic constraint matrix $Q_i$ based on the current constraint index (`current_qc_row_idx`).
    * Modified `readqps` to track `current_qc_row_idx` and handle the initialization and processing of the `QCMATRIX` section.

This change significantly broadens the class of optimization problems that can be read by `QPSReader.jl`.